### PR TITLE
Bump bzt to 1.16.25 to see online reports

### DIFF
--- a/environment_dev.yml
+++ b/environment_dev.yml
@@ -17,7 +17,7 @@ dependencies:
     - alembic==1.9.3
     - pylint==2.5.2                 #dev
     - debugpy==1.0.0b9              #dev
-    - bzt==1.15.3                   #dev
+    - bzt==1.16.25                  #dev
     - pytest==7.2.0                 #dev
     - coverage==4.5.3               #dev
     - flake8==3.7.7                 #dev


### PR DESCRIPTION
# Bump bzt to version 1.16.25 to enable online reports

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual execution before and after version bump

### Before version bump:

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/fa54e139-f200-4bca-92db-a5d84a7f1dc0)

### After version bump:

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/cd8bae8d-1684-4630-99d4-a6003c13e7f0)


## Checklist:

- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
