### PR TITLE
Add delete product functionality

### DIFF
--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -66,6 +66,12 @@ class GatewayService(object):
             json.dumps({"id": product_data["id"]}), mimetype="application/json"
         )
 
+    @http("DELETE", "/products/<string:product_id>")
+    def delete_product(self, request, product_id):
+        """Deletes product by `product_id`"""
+        self.products_rpc.delete(product_id)
+        return Response(status="204", mimetype="application/json")
+
     @http("GET", "/orders/<int:order_id>", expected_exceptions=OrderNotFound)
     def get_order(self, request, order_id):
         """Gets the order details for the order given by `order_id`.

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -75,6 +75,16 @@ class TestCreateProduct(object):
         assert response.json()["error"] == "VALIDATION_ERROR"
 
 
+class TestDeleteProduct(object):
+    def test_can_delete_product(self, gateway_service, web_session):
+        response = web_session.delete("/products/the_odyssey")
+
+        assert response.status_code == 204
+        assert gateway_service.products_rpc.delete.call_args_list == [
+            call("the_odyssey")
+        ]
+
+
 class TestGetOrder(object):
     def test_can_get_order(self, gateway_service, web_session):
         # setup mock orders-service response:

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -51,6 +51,9 @@ class StorageWrapper:
     def create(self, product):
         self.client.hmset(self._format_key(product["id"]), product)
 
+    def delete(self, product_id):
+        return self.client.delete(self._format_key(product_id))
+
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(self._format_key(product_id), "in_stock", -amount)
 

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -29,6 +29,10 @@ class ProductsService:
         product = schemas.Product(strict=True).load(product).data
         self.storage.create(product)
 
+    @rpc
+    def delete(self, product_id):
+        self.storage.delete(product_id)
+
     @event_handler("orders", "order_created")
     def handle_order_created(self, payload):
         for product in payload["order"]["order_details"]:

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -45,6 +45,16 @@ def test_create(product, redis_client, storage):
     assert product["in_stock"] == int(stored_product[b"in_stock"])
 
 
+def test_delete(storage, products):
+    result = storage.delete("LZ129")
+    assert result == 1
+
+
+def test_delete_missing_product(storage, products):
+    result = storage.delete("Invalid")
+    assert result == 0
+
+
 def test_decrement_stock(storage, create_product, redis_client):
     create_product(id=1, title="LZ 127", in_stock=10)
     create_product(id=2, title="LZ 129", in_stock=11)

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -114,6 +114,17 @@ def test_create_product_validation_error_on_non_nullable_fields(
     assert {field: ["Field may not be null."]} == exc_info.value.args[0]
 
 
+def test_delete_product(create_product, service_container):
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, "delete") as delete:
+        delete(stored_product["id"])
+
+    with pytest.raises(NotFound):
+        with entrypoint_hook(service_container, "get") as get:
+            get(stored_product["id"])
+
+
 def test_handle_order_created(test_config, products, redis_client, service_container):
     dispatch = event_dispatcher()
 

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -64,6 +64,10 @@ scenarios:
         product_key: $.id
         default: NOT_FOUND
 
+    - if: '"${product_key}" == "NOT_FOUND"'
+      then:
+        - action: continue
+
     # 3. Create Orders
     - url: /orders
       label: orders-create
@@ -108,7 +112,19 @@ scenarios:
     - if: '"${order_id}" == "NOT_FOUND"'
       then:
         - action: continue
-  
+
+    # 5. Delete Product
+    - url: /products/${product_id}
+      label: product-delete
+      think-time: uniform(0s, 0s)
+      method: DELETE
+
+      assert:
+      - contains:
+        - 204
+        subject: http-code
+        not: false
+
 reporting:
 - module: final-stats
   dump-xml: stats.xml

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -52,3 +52,14 @@ ID=$(echo ${ORDER_ID} | jq '.id')
 # Test: Get Order back
 echo "=== Getting Order ==="
 curl -s "${STD_APP_URL}/orders/${ID}" | jq .
+
+# Test: Deleting a Product
+## (Test: Deleting a Product) Delete Product
+echo "=== Deleting product id: the_odyssey ==="
+curl -s -XDELETE  "${STD_APP_URL}/products/the_odyssey" \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json'
+echo
+## (Test: Deleting a Product) Get Product should now fail
+echo "=== Getting product id: the_odyssey (Should fail) ==="
+curl -s "${STD_APP_URL}/products/the_odyssey" | jq .


### PR DESCRIPTION
# Enhance product service with functionality to delete products 

## Description

This change adds the feature of deleting products to the product service. This feature is provided through the gateway service.

```bash
curl -s -X DELETE "${STD_APP_URL}/products/the_odyssey" \
    -H 'accept: application/json' \
    -H 'Content-Type: application/json' 
```

In the interest of idempotence, the `DELETE` request leads to a **204** response whether the resource to be deleted exists or not. This approach upholds the [RFC 7231, section 4.3.5 DELETE](https://www.rfc-editor.org/rfc/rfc7231#section-4.3.5) and [RFC 7231, section 6.5.4 404 Not Found](https://www.rfc-editor.org/rfc/rfc7231#section-6.5.4).

OBS: There's a larger discussion around this as seen in the StackOverflow thread [Status code when deleting a resource using HTTP DELETE for the second time](https://stackoverflow.com/questions/6439416/status-code-when-deleting-a-resource-using-http-delete-for-the-second-time). However, this discussion is beyond the scope of the PR.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Smoke tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the smoke tests targeting the local deployment
./test/nex-smoketest.sh local
```

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/3f016a39-6485-49f1-97e9-2d561b72672e)


### Unit tests

```
# Triggers the unit tests
./dev_pytest.sh
```

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/a36074f3-de33-4563-a2e9-eeeceee451a6)


### Load tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the load tests targeting the local deployment
./test/nex-bzt.sh local
```

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/68d50d83-3611-4a67-baab-fcc43dd43d72)

OBS: The error percentage refers to collision. The collision happens when a product has been deleted and we try to create/retrieve an order referring to a deleted product. I subscribe to the position that showcasing such behavior via load testing is a way to represent real-world behavior. A similar opinion can be found in the StackOverflow thread [Delete data without collision? (JMeter)](https://stackoverflow.com/questions/77039075/delete-data-without-collision-jmeter)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, where relevant
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
