### PR TITLE
Add list orders functionality

### DIFF
--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -164,3 +164,15 @@ class GatewayService(object):
         serialized_data = CreateOrderSchema().dump(order_data).data
         result = self.orders_rpc.create_order(serialized_data["order_details"])
         return result["id"]
+
+    @http("GET", "/orders")
+    def list_orders(self, request):
+        """Gets a list of all existing orders with their order details
+
+        Does not enhance the order details with full product details.
+        """
+        orders = self.orders_rpc.list_orders()
+
+        return Response(
+            GetOrderSchema(many=True).dumps(orders).data, mimetype="application/json"
+        )

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -276,3 +276,55 @@ class TestCreateOrder(object):
         assert response.status_code == 404
         assert response.json()["error"] == "PRODUCT_NOT_FOUND"
         assert response.json()["message"] == "Product Id unknown"
+
+
+class TestListOrders(object):
+    def test_can_list_orders(self, gateway_service, web_session):
+        # setup mock orders-service response:
+        gateway_service.orders_rpc.list_orders.return_value = [
+            {
+                "id": 1,
+                "order_details": [
+                    {
+                        "id": 1,
+                        "quantity": 2,
+                        "product_id": "the_odyssey",
+                        "price": "200.00",
+                    },
+                    {
+                        "id": 2,
+                        "quantity": 1,
+                        "product_id": "the_enigma",
+                        "price": "400.00",
+                    },
+                ],
+            }
+        ]
+
+        # call the gateway service to get order #1
+        response = web_session.get("/orders")
+        assert response.status_code == 200
+
+        expected_response = [
+            {
+                "id": 1,
+                "order_details": [
+                    {
+                        "id": 1,
+                        "quantity": 2,
+                        "product_id": "the_odyssey",
+                        "price": "200.00",
+                    },
+                    {
+                        "id": 2,
+                        "quantity": 1,
+                        "product_id": "the_enigma",
+                        "price": "400.00",
+                    },
+                ],
+            }
+        ]
+
+        assert expected_response == response.json()
+        # check dependencies called as expected
+        assert gateway_service.orders_rpc.list_orders.call_args_list == [call()]

--- a/orders/orders/service.py
+++ b/orders/orders/service.py
@@ -69,3 +69,8 @@ class OrdersService:
         order = self.db.query(Order).get(order_id)
         self.db.delete(order)
         self.db.commit()
+
+    @rpc
+    def list_orders(self):
+        orders = self.db.query(Order).all()
+        return OrderSchema(many=True).dump(orders).data

--- a/orders/test/interface/test_service.py
+++ b/orders/test/interface/test_service.py
@@ -90,3 +90,10 @@ def test_can_update_order(orders_rpc, order):
 def test_can_delete_order(orders_rpc, order, db_session):
     orders_rpc.delete_order(order.id)
     assert not db_session.query(Order).filter_by(id=order.id).count()
+
+
+def test_can_list_orders(orders_rpc, order):
+    orders = orders_rpc.list_orders()
+
+    assert len(orders) == 1
+    assert orders_rpc.list_orders()[0]["id"] == order.id

--- a/orders/test/unit/test_models.py
+++ b/orders/test/unit/test_models.py
@@ -29,3 +29,17 @@ def test_can_create_order_detail(db_session):
     assert order_detail_2.product_id == "the_odyssey"
     assert order_detail_2.price == 99.50
     assert order_detail_2.quantity == 2
+
+
+def test_can_list_orders(db_session):
+    order1 = Order()
+    order2 = Order()
+
+    db_session.add(order1)
+    db_session.add(order2)
+    db_session.commit()
+
+    expected = set([order1, order2])
+    actual = set(db_session.query(Order).all())
+
+    assert actual == expected

--- a/test/nex-bzt.yml
+++ b/test/nex-bzt.yml
@@ -125,6 +125,18 @@ scenarios:
         subject: http-code
         not: false
 
+    # 6. List Orders
+    - url: /orders
+      label: order-list
+      think-time: uniform(0s, 0s)
+      method: GET
+
+      assert:
+      - contains:
+        - 200
+        subject: http-code
+        not: false
+
 reporting:
 - module: final-stats
   dump-xml: stats.xml

--- a/test/nex-smoketest.sh
+++ b/test/nex-smoketest.sh
@@ -63,3 +63,9 @@ echo
 ## (Test: Deleting a Product) Get Product should now fail
 echo "=== Getting product id: the_odyssey (Should fail) ==="
 curl -s "${STD_APP_URL}/products/the_odyssey" | jq .
+echo
+
+# Test: Get List of orders
+echo "=== Getting list of Orders ==="
+curl -s "${STD_APP_URL}/orders" | jq .
+echo


### PR DESCRIPTION
# Enhance order service with functionality to list existing orders

## Description

This change adds the feature of listing orders to the order service. This feature is provided through the gateway service.

```bash
curl -s "${STD_APP_URL}/orders"
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Smoke tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the smoke tests targeting the local deployment
./test/nex-smoketest.sh local
```

### Unit tests

```
# Triggers the unit tests
./dev_pytest.sh
```

### Load tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the load tests targeting the local deployment
./test/nex-bzt.sh local
```

![image](https://github.com/Benardi/nameko-devexp/assets/9937551/004c7dfd-910c-4431-86f8-ebc1437a9863)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, where relevant
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings