### PR TITLE
Enhance product retrieval in order-related calls

### DIFF
--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -153,9 +153,8 @@ class GatewayService(object):
 
     def _create_order(self, order_data):
         # check order product ids are valid
-        valid_product_ids = {prod["id"] for prod in self.products_rpc.list()}
         for item in order_data["order_details"]:
-            if item["product_id"] not in valid_product_ids:
+            if not self.products_rpc.exists(item["product_id"]):
                 raise ProductNotFound("Product Id {}".format(item["product_id"]))
 
         # Call orders-service to create the order.

--- a/gateway/gateway/service.py
+++ b/gateway/gateway/service.py
@@ -88,9 +88,6 @@ class GatewayService(object):
         # raise``OrderNotFound``
         order = self.orders_rpc.get_order(order_id)
 
-        # Retrieve all products from the products service
-        product_map = {prod["id"]: prod for prod in self.products_rpc.list()}
-
         # get the configured image root
         image_root = config["PRODUCT_IMAGE_ROOT"]
 
@@ -98,7 +95,7 @@ class GatewayService(object):
         for item in order["order_details"]:
             product_id = item["product_id"]
 
-            item["product"] = product_map[product_id]
+            item["product"] = self.products_rpc.get(product_id)
             # Construct an image url.
             item["image"] = "{}/{}.jpg".format(image_root, product_id)
 

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -102,7 +102,7 @@ class TestGetOrder(object):
         }
 
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
+        gateway_service.products_rpc.get.side_effect = [
             {
                 "id": "the_odyssey",
                 "title": "The Odyssey",
@@ -160,7 +160,10 @@ class TestGetOrder(object):
 
         # check dependencies called as expected
         assert [call(1)] == gateway_service.orders_rpc.get_order.call_args_list
-        assert [call()] == gateway_service.products_rpc.list.call_args_list
+        assert [
+            call("the_odyssey"),
+            call("the_enigma"),
+        ] == gateway_service.products_rpc.get.call_args_list
 
     def test_order_not_found(self, gateway_service, web_session):
         gateway_service.orders_rpc.get_order.side_effect = OrderNotFound("missing")

--- a/gateway/test/interface/test_service.py
+++ b/gateway/test/interface/test_service.py
@@ -176,22 +176,7 @@ class TestGetOrder(object):
 class TestCreateOrder(object):
     def test_can_create_order(self, gateway_service, web_session):
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                "id": "the_odyssey",
-                "title": "The Odyssey",
-                "maximum_speed": 3,
-                "in_stock": 899,
-                "passenger_capacity": 100,
-            },
-            {
-                "id": "the_enigma",
-                "title": "The Enigma",
-                "maximum_speed": 200,
-                "in_stock": 1,
-                "passenger_capacity": 4,
-            },
-        ]
+        gateway_service.products_rpc.exists.return_value = True
 
         # setup mock create response
         gateway_service.orders_rpc.create_order.return_value = {
@@ -212,7 +197,9 @@ class TestCreateOrder(object):
         )
         assert response.status_code == 200
         assert response.json() == {"id": 11}
-        assert gateway_service.products_rpc.list.call_args_list == [call()]
+        assert gateway_service.products_rpc.exists.call_args_list == [
+            call("the_odyssey")
+        ]
         assert gateway_service.orders_rpc.create_order.call_args_list == [
             call([{"product_id": "the_odyssey", "quantity": 3, "price": "41.00"}])
         ]
@@ -245,22 +232,7 @@ class TestCreateOrder(object):
         self, gateway_service, web_session
     ):
         # setup mock products-service response:
-        gateway_service.products_rpc.list.return_value = [
-            {
-                "id": "the_odyssey",
-                "title": "The Odyssey",
-                "maximum_speed": 3,
-                "in_stock": 899,
-                "passenger_capacity": 100,
-            },
-            {
-                "id": "the_enigma",
-                "title": "The Enigma",
-                "maximum_speed": 200,
-                "in_stock": 1,
-                "passenger_capacity": 4,
-            },
-        ]
+        gateway_service.products_rpc.exists.return_value = False
 
         # call the gateway service to create the order
         response = web_session.post(
@@ -276,6 +248,7 @@ class TestCreateOrder(object):
         assert response.status_code == 404
         assert response.json()["error"] == "PRODUCT_NOT_FOUND"
         assert response.json()["message"] == "Product Id unknown"
+        assert gateway_service.products_rpc.exists.call_args_list == [call("unknown")]
 
 
 class TestListOrders(object):

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -55,7 +55,11 @@ class StorageWrapper:
         return self.client.delete(self._format_key(product_id))
 
     def exists(self, product_id):
-        return self.client.exists(self._format_key(product_id))
+        """Returns whether the product_id is tied to an existing product.
+
+        This method assumes it's receiving a single product_id as its paramater.
+        """
+        return self.client.exists(self._format_key(product_id)) == 1
 
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(self._format_key(product_id), "in_stock", -amount)

--- a/products/products/dependencies.py
+++ b/products/products/dependencies.py
@@ -54,6 +54,9 @@ class StorageWrapper:
     def delete(self, product_id):
         return self.client.delete(self._format_key(product_id))
 
+    def exists(self, product_id):
+        return self.client.exists(self._format_key(product_id))
+
     def decrement_stock(self, product_id, amount):
         return self.client.hincrby(self._format_key(product_id), "in_stock", -amount)
 

--- a/products/products/service.py
+++ b/products/products/service.py
@@ -33,6 +33,10 @@ class ProductsService:
     def delete(self, product_id):
         self.storage.delete(product_id)
 
+    @rpc
+    def exists(self, product_id):
+        return self.storage.exists(product_id)
+
     @event_handler("orders", "order_created")
     def handle_order_created(self, payload):
         for product in payload["order"]["order_details"]:

--- a/products/test/test_dependencies.py
+++ b/products/test/test_dependencies.py
@@ -55,6 +55,15 @@ def test_delete_missing_product(storage, products):
     assert result == 0
 
 
+def test_exists_on_existing_product(product, storage):
+    storage.create(product)
+    assert storage.exists("LZ127")
+
+
+def test_exists_on_missing_product(storage):
+    assert not storage.exists("unknown")
+
+
 def test_decrement_stock(storage, create_product, redis_client):
     create_product(id=1, title="LZ 127", in_stock=10)
     create_product(id=2, title="LZ 129", in_stock=11)

--- a/products/test/test_service.py
+++ b/products/test/test_service.py
@@ -125,6 +125,22 @@ def test_delete_product(create_product, service_container):
             get(stored_product["id"])
 
 
+def test_check_if_product_exists(create_product, service_container):
+    stored_product = create_product()
+
+    with entrypoint_hook(service_container, "exists") as exists:
+        result = exists(stored_product["id"])
+
+    assert result
+
+
+def test_check_if_missing_product_exists(service_container):
+    with entrypoint_hook(service_container, "exists") as exists:
+        result = exists("unknown")
+
+    assert not result
+
+
 def test_handle_order_created(test_config, products, redis_client, service_container):
     dispatch = event_dispatcher()
 


### PR DESCRIPTION
# Enhance product retrieval in the order service operations

## Description

The order service's operations (`get order` and `create order`) currently pull all existing products into memory to validate the relevant orders. This becomes a great issue as the number of products scales, **degrading the performance** of the services.

To solve this issue I have:
* Added an `exists` RPC call to use the product's ID to check if it exists. 
* Employed this call to avoid pulling all the existing products into memory,  enhancing product validation.

#### [Load Test Execution before change](https://a.blazemeter.com/app/?public-token=odRjPXBmr0KrcskRlZOxP1RvuhKjaDwNVPIYXhxPQa1g4a4sJk#/accounts/-1/workspaces/-1/projects/-1/sessions/r-ext-66907e89b31e5762120495/summary/summary) starting from 600 products

![image](https://github.com/user-attachments/assets/8f827ff2-7588-4f79-b364-b2243f96529d)

#### [Load Test Execution after change](https://a.blazemeter.com/app/?public-token=0NU499s6Cz2vBAPtujcrpQEI9ak48jjqZZtT5d9bwjxTp6Kk7F#/accounts/-1/workspaces/-1/projects/-1/sessions/r-ext-6690867ddf344779353617/summary/summary) starting from 2300 products

![image](https://github.com/user-attachments/assets/eb7bd8b1-f352-419e-a5c5-107a7cf8acae)

### <ins> The load tests show that the performance degradation has been solved! </ins>


> OBS: In the Load Tests above the requests "delete product" and "list orders" were not covered:   
> * The request "delete product" reduces the number of products, hiding the degradation
> * The request "list orders" is O(n) in time complexity where "n" refers to the number of orders,  and doesn't rely on products.
>
> In the test section I have displayed the full stat requests covering all requests

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change which adds or improves functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Smoke tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the smoke tests targeting the local deployment
./test/nex-smoketest.sh local
```

### Unit tests

```
# Triggers the unit tests
./dev_pytest.sh
```

### Load tests

```
# Deploy the services, this occupies a terminal
./dev_run.sh gateway.service orders.service products.service

# Triggers the load tests targeting the local deployment
./test/nex-bzt.sh local
```

#### [Request stats before change](https://a.blazemeter.com/app/?public-token=yIlancI6MaldOjZZss4BDgBj9a8d3jtxc19EXuLipJKuf37RSH#/accounts/-1/workspaces/-1/projects/-1/sessions/r-ext-66905c213605c989509836/summary/summary)

|Operation                      |# Samples|Avg. Response Time (ms)|90% line (ms)|95% line (ms)|99% line (ms)|Min Response Time (ms)|Max Response Time (ms)|Error Percentage|
|--------------------------------|---------|-----------------------|-------------|-------------|-------------|----------------------|----------------------|----------------|
|ALL                             |1712     |365                    |1122         |1783         |3498         |23                    |7484                  |0.47            |
|order-get|285      |221                    |339          |411          |1066         |59                    |1294                  |1.75            |
|order-list|280      |1447                   |2478         |3724         |7288         |63                    |7484                  |0               |
|orders-create|289      |275                    |417          |511          |1651         |75                    |1792                  |1.04            |
|product-delete|280      |82                     |123          |144          |321          |23                    |524                   |0               |
|product-get|289      |84                     |118          |168          |356          |25                    |633                   |0               |
|product-create|289      |102                    |166          |221          |336          |30                    |492                   |0               |

#### [Request stats after change](https://a.blazemeter.com/app/?public-token=qQrD6IBGcYbGVj4exohU1hkjq3qomCwFASNUDgbTmjpn8uGenn#/accounts/-1/workspaces/-1/projects/-1/sessions/r-ext-669052c81811d116959573/summary/summary)

|Operation                       |# Samples|Avg. Response Time (ms)|90% line (ms)|95% line (ms)|99% line (ms)|Min Response Time (ms)|Max Response Time (ms)|Error Percentage|
|-------------|---------|-----------------------|-------------|-------------|-------------|----------------------|----------------------|----------------|
|ALL          |2326     |270                    |1110         |1740         |2278         |13                    |2992                  |0               |
|order-get    |388      |96                     |134          |154          |267          |34                    |464                   |0               |
|order-list   |387      |1244                   |2186         |2308         |2638         |33                    |2992                  |0               |
|orders-create|388      |127                    |168          |198          |404          |48                    |823                   |0               |
|product-delete|387      |49                     |76           |92           |162          |15                    |288                   |0               |
|product-get  |388      |46                     |69           |79           |113          |13                    |225                   |0               |
|products-create|388      |58                     |88           |101          |153          |20                    |407                   |0               |


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
